### PR TITLE
Fixed lowercase inputs

### DIFF
--- a/src/roman.py
+++ b/src/roman.py
@@ -96,9 +96,12 @@ romanNumeralPattern = re.compile("""
 
 def fromRoman(s):
     """convert Roman numeral to integer"""
+    
     if not s:
         raise InvalidRomanNumeralError('Input cannot be blank')
 
+    s = s.upper() #Handle lowercase inputs
+    
     # special case
     if s == 'N':
         return 0


### PR DESCRIPTION
The code used to raise exception for lowercase inputs, when used roman.fromRoman('xvi') for example, it gave:

Exception occured: Invalid Roman numeral: xvi

I could fix this issue by adding lowercase entries to the maps and patterns, but this simple fix would also fix the issue, and not make the code more cluttered.